### PR TITLE
new readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,21 @@
 # Peace Machine Presentation - Frontend
 
-<http://www.understandingpeace.net/>
+> This project handles frontend functionality of the Peace Machine presentation.
 
-<https://github.com/Rauhankone/peacemachine-presentation-frontend/>
+## Looking for the backend?
 
-<https://github.com/Rauhankone/peacemachine-presentation-backend/>
-
-This project handles frontend functionality of the Peace Machine
-presentation.
-
-It depends on the peacemachine-presentation-backend backend.
+[Rauhankone/peacemachine-presentation-backend](https://github.com/Rauhankone/peacemachine-presentation-backend/)
 
 ## Setup
 
-1. Set up the backend.
+1. Set up the [backend](https://github.com/Rauhankone/peacemachine-presentation-backend/).
 2. Make a copy of `.env.example` with name: `.env`.
 3. Fill in the host and port to it.
-4. Run `npm install` or `yarn`.
-5. Run `npm start` or `yarn start`.
+4. Run `yarn` to install dependencies.
+5. Run `yarn start` to start development.
 
 ## Contributors
 
-Contributors are listed in the CONTRIBUTORS.md file.
+Contributors are listed in the [CONTRIBUTORS.md](https://github.com/Rauhankone/peacemachine-presentation-frontend/commit/d10a386ccc20a5c93c715288a4a2d17a7bed9856) file.
 
-Made by Digitalents with help from Futurice.
-
-<http://digitalents.munstadi.fi/en/>
-
-<https://futurice.com/>
+Made by [Digitalents Helsinki](http://digitalents.munstadi.fi/en/) Helsinki with help from [Futurice](https://futurice.com/).


### PR DESCRIPTION
Improved and restructured README.md, using markdown to its fullest.

For example, instead of this;
```markdown
Contributors are listed in the CONTRIBUTORS.md file.

Made by Digitalents with help from Futurice.

<http://digitalents.munstadi.fi/en/>

<https://futurice.com/>
```

Use this;
```markdown
Contributors are listed in the [CONTRIBUTORS.md](https://github.com/Rauhankone/peacemachine-presentation-frontend/commit/d10a386ccc20a5c93c715288a4a2d17a7bed9856) file.

Made by [Digitalents Helsinki](http://digitalents.munstadi.fi/en/) Helsinki with help from [Futurice](https://futurice.com/).
```